### PR TITLE
Fix Codecov step and document CI secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,31 @@ jobs:
         run: |
           python -m pip install -r requirements-dev.txt
           python -m pip install .
+      # Lance les tests en échouant si la couverture descend sous 80 %
       - name: Exécuter les tests
-        run: pytest --cov=src --cov-report=xml
+        run: pytest --cov=src --cov-report=xml --cov-fail-under=80
+      # Téléverse la couverture en tant qu'artefact si Coveralls est activé
+      - name: Téléverser artefact couverture
+        if: ${{ secrets.USE_COVERALLS != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+      # Envoie la couverture à Codecov
       - name: Publier sur Codecov
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true
-          minimum_coverage: 80
+          token: ${{ secrets.CODECOV_TOKEN }}
+      # Installe Coveralls si demandé
+      - name: Installer Coveralls
+        if: ${{ secrets.USE_COVERALLS == 'true' }}
+        run: pip install coveralls
+      # Publie la couverture sur Coveralls
+      - name: Publier sur Coveralls
+        if: ${{ secrets.USE_COVERALLS == 'true' }}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: coveralls --service=github

--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ La feuille de route complète est détaillée dans le fichier `roadmap` à la ra
 ## Conformité RTS 6
 
 La conformité à la directive MiFID II et aux exigences RTS 6 est documentée dans `docs/compliance/RTS6_checklist.md`.
+
+## ⚠️ Configuration des secrets CI
+
+Pour utiliser la publication de la couverture, créez les secrets :
+
+- `CODECOV_TOKEN` pour l'upload Codecov.
+- `COVERALLS_REPO_TOKEN` (requis si `USE_COVERALLS` vaut `true`).


### PR DESCRIPTION
## Summary
- enforce coverage threshold in tests
- make Codecov upload use `CODECOV_TOKEN`
- allow optional Coveralls publishing with artefact upload
- document CI secrets in README

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685924dca808832495b370b93b589248