### PR TITLE
Implement repo hardening and CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 ################################################################################
-# 3 ▸ Job unique : tests + couverture + upload(s)
+# 3 ▸ Job tests
 ################################################################################
 jobs:
   test:
@@ -52,20 +52,7 @@ jobs:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
 
-      # 3.6 – Upload vers Codecov (SEULEMENT push direct sur main **et** depuis
-      #        ton repo, donc aucun secret n’est exposé aux forks/PR)
-      - name: Publier sur Codecov
-        if: github.event_name == 'push'               &&   # un push
-            github.ref == 'refs/heads/main'           &&   # sur main
-            github.repository_owner == 'GordoxGit'         # depuis ton dépôt
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
-
-      # 3.7 – Upload vers Coveralls (facultatif via secret USE_COVERALLS=true)
+      # 3.6 – Upload vers Coveralls (facultatif via secret USE_COVERALLS=true)
       - name: Publier sur Coveralls
         if: env.USE_COVERALLS == 'true' &&
             github.event_name == 'push' &&
@@ -76,3 +63,21 @@ jobs:
         run: |
           pip install coveralls
           coveralls --service=github
+
+  coverage:
+    needs: test
+    if: github.repository_owner == 'GordoxGit' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 coverage.xml
+.vscode/
+venv/
+*.env
+*.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # StockGenius XAU
 
-![CI](https://github.com/your-org/StockGeniusXAU/actions/workflows/ci.yml/badge.svg)
-![Codecov](https://codecov.io/gh/your-org/StockGeniusXAU/branch/main/graph/badge.svg)
+[![CI](https://github.com/GordoxGit/StockGeniusXAU/actions/workflows/ci.yml/badge.svg)](https://github.com/GordoxGit/StockGeniusXAU/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/GordoxGit/StockGeniusXAU/branch/main/graph/badge.svg)](https://codecov.io/gh/GordoxGit/StockGeniusXAU)
 
 ## Vision
 
@@ -25,3 +25,7 @@ Pour utiliser la publication de la couverture, créez les secrets :
 
 - `CODECOV_TOKEN` pour l'upload Codecov.
 - `COVERALLS_REPO_TOKEN` (requis si `USE_COVERALLS` vaut `true`).
+
+Le token Codecov se génère depuis votre tableau de bord Codecov
+(`Settings → Upload Token`). Une fois obtenu, ajoutez-le dans GitHub comme
+`CODECOV_TOKEN` via **Settings → Secrets and variables → Actions**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+Nous prenons la sécurité très au sérieux. Pour signaler une vulnérabilité,
+merci d'envoyer un email à `security@example.com` avec les détails
+nécessaires. Nous reviendrons vers vous sous 72 h.

--- a/docs/secrets/README.md
+++ b/docs/secrets/README.md
@@ -1,0 +1,10 @@
+# Gestion des secrets CI
+
+Les clés et tokens nécessaires (par ex. `CODECOV_TOKEN`, `BINANCE_API_KEY`)
+se configurent dans GitHub :
+
+1. Ouvrez le dépôt sur GitHub puis **Settings → Secrets and variables → Actions**.
+2. Cliquez sur **New repository secret** et saisissez le nom du secret.
+3. Collez la valeur fournie puis validez.
+
+Aucun secret ne doit être ajouté dans le code source ou le dépôt git.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,30 @@ build-backend = "setuptools.build_meta"
 name = "stockgenius-xau"
 version = "0.1.0"
 description = "Assistant de trading XAU/USD"
-authors = [{name="Equipe StockGenius"}]
+authors = [{name = "Equipe StockGenius"}]
 requires-python = ">=3.11"
+readme = "README.md"
+license = {text = "MIT"}
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "pandas",
     "numpy",
-    "pytest",
     "vectorbt",
-    "catboost[gpu]"
+    "catboost[gpu]",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
 ]
 
 [tool.setuptools.packages.find]

--- a/roadmap
+++ b/roadmap
@@ -2,3 +2,4 @@
 
 - Phase 0 : Bootstrapping
 - Phase 1 : Pipeline Données
+- Phase 0.1.1 : Hardening (Ticket 003)


### PR DESCRIPTION
## Summary
- ignore common dev artefacts
- document how to handle secrets
- add vulnerability disclosure policy
- update README badges and secrets section
- note hardening phase in roadmap
- improve metadata in `pyproject.toml`
- enable detect-secrets in pre-commit
- split CI into test and coverage jobs

## Testing
- `pre-commit run --files README.md SECURITY.md docs/secrets/README.md .gitignore pyproject.toml .github/workflows/ci.yml .pre-commit-config.yaml roadmap`
- `detect-secrets scan`
- `pytest --cov=src --cov-report=xml --cov-fail-under=80`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_68594be342e483249ac1cfaecba2f13c