### PR TITLE
Add technical indicators and strategy

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,0 +1,19 @@
+# Module `xau.signals`
+
+Ce module regroupe plusieurs indicateurs techniques classiques calculés en mémoire avec **pandas** :
+
+- **RSI** – formule originale de J. W. Wilder (1978) avec exemples issus d'AskPython.
+- **MACD** – convergence/divergence de moyennes mobiles exposée par Alpharithms.
+- **ATR** – mesure de volatilité décrite sur Investopedia.
+- **Moyennes mobiles** – simples (SMA) via `pandas.Series.rolling`.
+
+```python
+from xau.signals import rsi, macd, atr, moving_average
+```
+
+Un exemple de backtest léger peut être réalisé avec [vectorbt](https://vectorbt.dev/):
+
+```python
+from xau.signals import generate_signal
+signal = generate_signal(df)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.mypy]
+ignore_missing_imports = true
+python_version = "3.11"
+

--- a/src/xau/signals/__init__.py
+++ b/src/xau/signals/__init__.py
@@ -1,1 +1,15 @@
-"""Package signals du projet."""
+"""Fonctions de génération de signaux techniques."""
+
+from .indicators import atr, macd, moving_average, rsi
+from .strategy import FLAT, LONG, SHORT, generate_signal
+
+__all__ = [
+    "atr",
+    "macd",
+    "moving_average",
+    "rsi",
+    "generate_signal",
+    "LONG",
+    "SHORT",
+    "FLAT",
+]

--- a/src/xau/signals/backtest.py
+++ b/src/xau/signals/backtest.py
@@ -1,0 +1,45 @@
+"""Backtest léger en mémoire avec vectorbt."""
+
+from __future__ import annotations
+
+import pandas as pd
+import vectorbt as vbt
+
+from .strategy import FLAT, LONG, SHORT
+
+
+def run_backtest(
+    df: pd.DataFrame,
+    signal: pd.Series,
+    on: str = "close",
+    cash: float = 1000.0,
+    fees: float = 0.0,
+) -> vbt.Portfolio:
+    """Exécute un backtest simple.
+
+    Args:
+        df: Données de marché.
+        signal: Série générée par :func:`generate_signal`.
+        on: Colonne du prix de référence.
+        cash: Capital initial.
+        fees: Frais de transaction proportionnels.
+
+    Returns:
+        Objet ``Portfolio`` vectorbt.
+    """
+    price = df[on]
+    entries = signal == LONG
+    exits = signal.shift().eq(LONG) & (signal != LONG)
+    short_entries = signal == SHORT
+    short_exits = signal.shift().eq(SHORT) & (signal != SHORT)
+    pf = vbt.Portfolio.from_signals(
+        price,
+        entries=entries,
+        exits=exits,
+        short_entries=short_entries,
+        short_exits=short_exits,
+        init_cash=cash,
+        fees=fees,
+        freq="D",
+    )
+    return pf

--- a/src/xau/signals/indicators.py
+++ b/src/xau/signals/indicators.py
@@ -1,0 +1,97 @@
+"""Indicateurs techniques basés sur Pandas."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def rsi(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Calcule le Relative Strength Index.
+
+    Args:
+        df: Données contenant une colonne ``close``.
+        period: Période utilisée pour le calcul.
+
+    Returns:
+        Série du RSI.
+    """
+    close = df["close"]
+    delta = close.diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    avg_gain = up.rolling(window=period, min_periods=period).mean()
+    avg_loss = down.rolling(window=period, min_periods=period).mean()
+    rsi = pd.Series(np.nan, index=df.index)
+    if len(df) >= period:
+        rs = avg_gain.iloc[period] / avg_loss.iloc[period]
+        rsi.iloc[period] = 100 - 100 / (1 + rs)
+        prev_gain = avg_gain.iloc[period]
+        prev_loss = avg_loss.iloc[period]
+        for i in range(period + 1, len(df)):
+            prev_gain = (prev_gain * (period - 1) + up.iloc[i]) / period
+            prev_loss = (prev_loss * (period - 1) + down.iloc[i]) / period
+            rsi.iloc[i] = 100 - 100 / (1 + prev_gain / prev_loss)
+    return rsi
+
+
+def macd(
+    df: pd.DataFrame, fast: int = 12, slow: int = 26, signal: int = 9
+) -> pd.DataFrame:
+    """Calcule la MACD (Moving Average Convergence Divergence).
+
+    Args:
+        df: Données avec une colonne ``close``.
+        fast: Période de l'EMA rapide.
+        slow: Période de l'EMA lente.
+        signal: Période de la ligne signal.
+
+    Returns:
+        DataFrame avec colonnes ``macd``, ``signal`` et ``hist``.
+    """
+    close = df["close"]
+    ema_fast = close.ewm(span=fast, adjust=False).mean()
+    ema_slow = close.ewm(span=slow, adjust=False).mean()
+    macd_line = ema_fast - ema_slow
+    signal_line = macd_line.ewm(span=signal, adjust=False).mean()
+    hist = macd_line - signal_line
+    return pd.DataFrame({"macd": macd_line, "signal": signal_line, "hist": hist})
+
+
+def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Calcule l'Average True Range.
+
+    Args:
+        df: Données contenant ``high``, ``low`` et ``close``.
+        period: Période dissage.
+
+    Returns:
+        Série de l'ATR.
+    """
+    high = df["high"]
+    low = df["low"]
+    close = df["close"]
+    tr = pd.concat(
+        [
+            high - low,
+            (high - close.shift()).abs(),
+            (low - close.shift()).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    atr_series = tr.ewm(alpha=1 / period, adjust=False).mean()
+    atr_series.iloc[:period] = np.nan
+    return atr_series
+
+
+def moving_average(df: pd.DataFrame, period: int) -> pd.Series:
+    """Calcule la moyenne mobile simple.
+
+    Args:
+        df: Données avec une colonne ``close``.
+        period: Fenêtre de lissage.
+
+    Returns:
+        Série de la SMA.
+    """
+    return df["close"].rolling(window=period).mean()

--- a/src/xau/signals/strategy.py
+++ b/src/xau/signals/strategy.py
@@ -1,0 +1,41 @@
+"""Génération de signaux simples basés sur le RSI."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .indicators import atr, rsi
+
+
+LONG = "LONG"
+SHORT = "SHORT"
+FLAT = "FLAT"
+
+
+def generate_signal(
+    df: pd.DataFrame,
+    on: str = "close",
+    confirmation: bool = False,
+    rsi_period: int = 14,
+    atr_period: int = 14,
+) -> pd.Series:
+    """Génère un signal directionnel.
+
+    Args:
+        df: Données de marché contenant ``high``, ``low`` et ``close``.
+        on: Colonne utilisée pour le prix de clôture.
+        confirmation: Active un filtre ATR si ``True``.
+
+    Returns:
+        Série de signaux ``LONG``, ``SHORT`` ou ``FLAT``.
+    """
+    data = df.rename(columns={on: "close"})
+    signal = pd.Series(FLAT, index=data.index)
+    data["rsi"] = rsi(data, period=rsi_period)
+    signal[data["rsi"] > 70] = SHORT
+    signal[data["rsi"] < 30] = LONG
+    if confirmation:
+        data["atr"] = atr(data, period=atr_period)
+        threshold = data["atr"].median()
+        signal[data["atr"] <= threshold] = FLAT
+    return signal

--- a/tests/integration/test_backtest.py
+++ b/tests/integration/test_backtest.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from xau.signals import generate_signal
+from xau.signals.backtest import run_backtest
+
+
+def test_run_backtest() -> None:
+    close = [1, 2, 1, 2, 3, 4, 5, 6, 5, 4, 3, 2]
+    df = pd.DataFrame(
+        {
+            "close": close,
+            "high": [c + 0.5 for c in close],
+            "low": [c - 0.5 for c in close],
+        }
+    )
+    signal = generate_signal(df, rsi_period=3, atr_period=3)
+    pf = run_backtest(df, signal)
+    assert pf.stats()["Total Return [%]"] is not None

--- a/tests/integration/test_strategy.py
+++ b/tests/integration/test_strategy.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from xau.signals import FLAT, LONG, SHORT, generate_signal
+
+
+def test_generate_signal() -> None:
+    close = list(range(10)) + [5, 4]
+    df = pd.DataFrame(
+        {
+            "close": close,
+            "high": [c + 0.5 for c in close],
+            "low": [c - 0.5 for c in close],
+        }
+    )
+    out = generate_signal(df, confirmation=False, rsi_period=3, atr_period=3)
+    assert out.iloc[3] == SHORT
+    assert out.iloc[10] == FLAT
+    assert out.iloc[11] == LONG
+
+    out_conf = generate_signal(df, confirmation=True, rsi_period=3, atr_period=3)
+    assert out_conf.iloc[8] == SHORT
+    assert out_conf.iloc[11] == LONG

--- a/tests/unit/test_indicators.py
+++ b/tests/unit/test_indicators.py
@@ -1,0 +1,90 @@
+import pandas as pd
+
+from xau.signals import atr, macd, moving_average, rsi
+
+
+def test_rsi_reference() -> None:
+    prices = [
+        44.34,
+        44.09,
+        44.15,
+        43.61,
+        44.33,
+        44.83,
+        45.10,
+        45.42,
+        45.84,
+        46.08,
+        45.89,
+        46.03,
+        45.61,
+        46.28,
+        46.28,
+        46.00,
+        46.03,
+        46.41,
+        46.22,
+        45.64,
+        46.21,
+    ]
+    df = pd.DataFrame({"close": prices})
+    out = rsi(df)
+    assert round(out.iloc[14], 2) == 70.46
+    assert round(out.iloc[15], 2) == 66.25
+
+
+def test_macd_reference() -> None:
+    data = {
+        "close": [
+            77.44539475,
+            77.04557544,
+            74.89697204,
+            75.856461,
+            75.09194679,
+            76.20263178,
+            75.2301837,
+            73.84891755,
+            75.0113527,
+            77.14481412,
+            77.33058367,
+            76.85652616,
+            75.39394758,
+            76.7763823,
+            76.64038513,
+            77.20512022,
+            76.66007339,
+            70.90497216,
+            70.23598702,
+            71.817561,
+            71.565308,
+            72.495697,
+            72.908951,
+            72.699074,
+            73.712648,
+        ]
+    }
+    df = pd.DataFrame(data)
+    out = macd(df)
+    assert round(out["macd"].iloc[24], 3) == -1.097
+    assert round(out["signal"].iloc[24], 3) == -0.987
+
+
+def test_atr_reference() -> None:
+    df = pd.DataFrame(
+        {
+            "high": [10, 12, 11, 13, 15],
+            "low": [8, 9, 9, 10, 12],
+            "close": [9, 11, 10, 12, 14],
+        }
+    )
+    out = atr(df, period=3)
+    assert round(out.iloc[4], 3) == 2.654
+
+
+def test_moving_average() -> None:
+    df = pd.DataFrame({"close": [1, 2, 3, 4, 5]})
+    out = moving_average(df, 3)
+    assert pd.isna(out.iloc[0]) and pd.isna(out.iloc[1])
+    assert out.iloc[2] == 2.0
+    assert out.iloc[3] == 3.0
+    assert out.iloc[4] == 4.0


### PR DESCRIPTION
## Summary
- implement RSI, MACD, ATR and SMA calculations
- add a simple strategy generator and a vectorbt backtest helper
- document the new signals module
- provide unit and integration tests
- configure mypy to ignore missing imports

## Testing
- `ruff check src/xau/signals strategy tests`
- `black --check src/xau/signals tests/integration/test_strategy.py tests/integration/test_backtest.py tests/unit/test_indicators.py`
- `mypy src/xau/signals`
- `pytest -q --cov=src/xau/signals --cov-append --cov-report=term --cov-fail-under=85`

------
https://chatgpt.com/codex/tasks/task_e_68595da178ac8324a102d7213b3c54bb