### PR TITLE
Fix Windows CI to use Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
-        exclude:
-          - python-version: "3.10"
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -38,17 +36,11 @@ jobs:
   tests-windows:
     runs-on: windows-latest
     continue-on-error: true
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        exclude:
-          - python-version: "3.11"
-          - python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           cache: "pip"
       - name: Installer les dépendances MT5
         run: |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Le projet suit une structure modulaire permettant l'extension future des composa
 flowchart LR
     A[Sources externes] --> B[Module xau.data]
     B --> C[Fichiers Parquet]
-    C --> D[Analyse DuckDB]
+C --> D[Analyse DuckDB]
 ```
+
+## Pré-requis
+
+Ce projet nécessite **Python ≥ 3.11**.
 
 La documentation détaillée se trouve dans `docs/data_ingestion.md`.
 
@@ -42,8 +46,8 @@ Le token Codecov se génère depuis votre tableau de bord Codecov
 ## Dépendances optionnelles
 
 Certaines fonctionnalités d'exécution s'appuient sur la bibliothèque
-`MetaTrader5`. Celle-ci ne fournit des roues que pour Windows et n'est
-compatible qu'avec Python ≤ 3.11. L'installation peut se faire via l'extra
+`MetaTrader5`. Celle-ci n'est disponible que sur **Windows** et ne propose des
+roues que pour Python 3.11. L'installation peut se faire via l'extra
 `mt5` :
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "stockgenius-xau"
 version = "0.1.0"
 description = "Assistant de trading XAU/USD"
 authors = [{name = "Equipe StockGenius"}]
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.12"
 readme = "README.md"
 license = {text = "MIT"}
 classifiers = [
@@ -15,7 +15,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/tests/integration/test_broker_paper.py
+++ b/tests/integration/test_broker_paper.py
@@ -2,6 +2,12 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+
+if sys.platform != "win32" or sys.version_info >= (3, 12):
+    pytest.skip(
+        "Tests MT5 ignorés hors Windows ou Python>=3.12",
+        allow_module_level=True,
+    )
 from xau.signals import LONG
 
 

--- a/tests/unit/execution/__init__.py
+++ b/tests/unit/execution/__init__.py
@@ -1,1 +1,9 @@
 
+import sys
+import pytest
+
+if sys.platform != "win32" or sys.version_info >= (3, 12):
+    pytest.skip(
+        "Tests MT5 ignorés hors Windows ou Python>=3.12",
+        allow_module_level=True,
+    )

--- a/tests/unit/execution/test_broker.py
+++ b/tests/unit/execution/test_broker.py
@@ -2,6 +2,12 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+
+if sys.platform != "win32" or sys.version_info >= (3, 12):
+    pytest.skip(
+        "Tests MT5 ignorés hors Windows ou Python>=3.12",
+        allow_module_level=True,
+    )
 from xau.signals import LONG, FLAT
 
 

--- a/tests/unit/execution/test_mt5_client.py
+++ b/tests/unit/execution/test_mt5_client.py
@@ -5,8 +5,11 @@ import pytest
 
 from xau.execution.mt5_client import MT5_AVAILABLE
 
-if not MT5_AVAILABLE:
-    pytest.skip("MetaTrader5 non disponible", allow_module_level=True)
+if sys.platform != "win32" or sys.version_info >= (3, 12) or not MT5_AVAILABLE:
+    pytest.skip(
+        "Tests MT5 ignorés hors Windows, sous Python>=3.12 ou sans package",
+        allow_module_level=True,
+    )
 
 
 class DummyMT5:


### PR DESCRIPTION
## Summary
- run Linux tests on 3.11 and 3.12
- use Python 3.11 on Windows and install MT5 extra
- restrict package to Python >=3.11,<3.12
- document the requirement in README
- skip MT5 tests outside of Windows/3.11

## Testing
- `pytest -q`
- `pytest --cov=src --cov-report=xml --cov-fail-under=80 -q` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6859705acd888324a153e6dbb681de5f