### PR TITLE
Implement OnDeinit indicator cleanup

### DIFF
--- a/StockGeniusXAU.mq5
+++ b/StockGeniusXAU.mq5
@@ -53,6 +53,17 @@ int OnInit()
 
 void OnDeinit(const int reason)
   {
+   if(fast_ma_handle != INVALID_HANDLE)
+     {
+      IndicatorRelease(fast_ma_handle);
+      fast_ma_handle = INVALID_HANDLE;
+     }
+
+   if(slow_ma_handle != INVALID_HANDLE)
+     {
+      IndicatorRelease(slow_ma_handle);
+      slow_ma_handle = INVALID_HANDLE;
+     }
   }
 
 void OnTick()


### PR DESCRIPTION
## Summary
- release both moving average indicator handles during deinitialization to free resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff0bd7f5c8324bfc58b84aebae98d