### PR TITLE
Add OnTick pre-check for existing positions

### DIFF
--- a/StockGeniusXAU.mq5
+++ b/StockGeniusXAU.mq5
@@ -66,6 +66,44 @@ void OnDeinit(const int reason)
      }
   }
 
+bool HasManagedPositionOpen(const string symbol)
+  {
+   const int positions_total = PositionsTotal();
+   for(int index = 0; index < positions_total; ++index)
+     {
+      ulong ticket = PositionGetTicket(index);
+      if(ticket == 0)
+         continue;
+
+      if(!PositionSelectByTicket(ticket))
+         continue;
+
+      if(PositionGetInteger(POSITION_MAGIC) != Magic_Number)
+         continue;
+
+      if(PositionGetString(POSITION_SYMBOL) != symbol)
+         continue;
+
+      return(true);
+     }
+
+   return(false);
+  }
+
 void OnTick()
   {
+   if(HasManagedPositionOpen(_Symbol))
+      return;
+
+   // ------------------------------------------------------------------
+   // 1. Préparer les données de marché et les indicateurs nécessaires.
+   // ------------------------------------------------------------------
+
+   // ------------------------------------------------------------------
+   // 2. Vérifier les conditions de trading (entrées/sorties, filtres, etc.).
+   // ------------------------------------------------------------------
+
+   // ------------------------------------------------------------------
+   // 3. Calculer la taille de position, définir SL/TP et exécuter l'ordre.
+   // ------------------------------------------------------------------
   }


### PR DESCRIPTION
## Summary
- add a helper to detect open positions on the current symbol managed by the EA
- structure OnTick to exit early when a managed position already exists and outline the future processing steps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cffd3f2e24832486097d8b40865968